### PR TITLE
Updated to build with Lispworks 7

### DIFF
--- a/src/nox/core-constants.lisp
+++ b/src/nox/core-constants.lisp
@@ -102,11 +102,12 @@
   (defequal -owl-uri-  "http://www.w3.org/2002/07/owl#")
   (defequal -daml-uri- "http://www.daml.org/2000/12/daml+oil#"))
 
-(defmacro rdf-uri (string)  `(concatenate 'string -rdf-uri- ,string))
-(defmacro rdfs-uri (string) `(concatenate 'string -rdfs-uri- ,string))
-(defmacro xsd-uri (string)  `(concatenate 'string -xsd-uri- ,string))
-(defmacro owl-uri (string)  `(concatenate 'string -owl-uri- ,string))
-(defmacro daml-uri (string) `(concatenate 'string -daml-uri- ,string))
+(eval-when (:compile-toplevel :load-toplevel)
+  (defmacro rdf-uri (string)  `(concatenate 'string -rdf-uri- ,string))
+  (defmacro rdfs-uri (string) `(concatenate 'string -rdfs-uri- ,string))
+  (defmacro xsd-uri (string)  `(concatenate 'string -xsd-uri- ,string))
+  (defmacro owl-uri (string)  `(concatenate 'string -owl-uri- ,string))
+  (defmacro daml-uri (string) `(concatenate 'string -daml-uri- ,string)))
 
 (defequal -alternate-rdf-uri-
   #."http://www.w3.org/TR/REC-rdf-syntax/")

--- a/src/nox/xml-util.lisp
+++ b/src/nox/xml-util.lisp
@@ -207,13 +207,21 @@
   (warn "No working WITHOUT-INTERRUPTS in this implementation")
   `(progn ,@body))
 
-#-:digitool
+#-(or :digitool :lispworks)
 (defmacro atomic-push (thing place)
   `(without-interrupts (push ,thing ,place)))
 
-#-:digitool
+#+:lispworks
+(defmacro atomic-push (thing place)
+  `(sys:atomic-push ,thing ,place))
+
+#-(or :digitool :lispworks)
 (defmacro atomic-pop (place)
   `(without-interrupts (pop ,place)))
+
+#+:lispworks
+(defmacro atomic-pop (place)
+  `(sys:atomic-pop ,place))
 
 (defun allocate-resource-from-pool (pool &rest args)
   #+:digitool
@@ -381,13 +389,13 @@
            (read-char stream t nil t) ; skip #\>
            (return (concatenate 'string (nreverse chars)))))))
 
-
-(defmacro whitespace-char-p (char)
-  (with-temps (c)
-    `(let ((,c ,char))
-       ;; let's assume this works for now :-)
-       (or (char= ,c #\Space)
-           (not (graphic-char-p ,c))))))
+(eval-when (:compile-toplevel :load-toplevel)
+  (defmacro whitespace-char-p (char)
+    (with-temps (c)
+      `(let ((,c ,char))
+         ;; let's assume this works for now :-)
+         (or (char= ,c #\Space)
+             (not (graphic-char-p ,c)))))))
 
 
 (defequal -whitespace-chars-

--- a/src/platform.lisp
+++ b/src/platform.lisp
@@ -123,7 +123,7 @@
 ;;;   LOCKS
 ;;;
 
-#-(and :digitool :CCL-5.2)              ; already defined
+#-(or lispworks (and :digitool :CCL-5.2))              ; already defined
 (defmacro with-lock ((lock &rest args) &body body)
   #+(or :digitool :clozure)  `(with-lock-grabbed (,lock ,@args) ,@body)
   #+:excl `(mp:with-process-lock (,lock ,@args) ,@body)


### PR DESCRIPTION
This small set of changes makes it possible to build with lw7, and does not seem to affect building with sbcl and ccl.