### PR TITLE
Collapse whitespace

### DIFF
--- a/src/nox/xml-util.lisp
+++ b/src/nox/xml-util.lisp
@@ -382,12 +382,11 @@
            (return (concatenate 'string (nreverse chars)))))))
 
 
-(defmacro whitespace-char-p (char)
-  (with-temps (c)
-    `(let ((,c ,char))
-       ;; let's assume this works for now :-)
-       (or (char= ,c #\Space)
-           (not (graphic-char-p ,c))))))
+(defun whitespace-char-p (char)
+  "Return true if CHAR is a whitespace character.
+Argument CHAR has to be a character object."
+  (declare (type character char))
+  (or (char= char #\Space) (not (graphic-char-p char))))
 
 
 (defequal -whitespace-chars-


### PR DESCRIPTION
I had a problem when parsing an UTF-8 encoded RDF/XML document.

     (wilbur:collapse-whitespace "Grüß Gott")

Signals an error:

     Cannot decode this: (#\LATIN_SMALL_LETTER_U_WITH_DIAERESIS
                          #\LATIN_SMALL_LETTER_SHARP_S #\  #\G #\o
                          #\t #\t)
        [Condition of type SIMPLE-ERROR]

Here is a fix.